### PR TITLE
ScrollView Bug Fix

### DIFF
--- a/jisikin-ios/jisikin-ios/QuestionDetailFromWritingAnswerViewController.swift
+++ b/jisikin-ios/jisikin-ios/QuestionDetailFromWritingAnswerViewController.swift
@@ -38,6 +38,7 @@ class SimpleQuestionView:UIView {
         questionTitleView = UILabel()
         questionTitleView.font = questionTitleView.font.withSize(30)
         questionTitleView.textColor = .black
+        questionTitleView.numberOfLines = 0
         questionTitleView.text = "게임 이름 기억 안남"
      
         questionUserInfo = UILabel()
@@ -47,7 +48,7 @@ class SimpleQuestionView:UIView {
         questionContentView = UILabel()
         questionContentView.text = ""
         questionContentView.numberOfLines = 0
-        questionContentView.lineBreakMode = .byWordWrapping
+        questionContentView.lineBreakMode = .byCharWrapping
         questionContentView.font = questionTitleView.font.withSize(20)
         
         questionTimeView = UILabel()
@@ -231,5 +232,8 @@ class QuestionDetailFromWritingAnswerViewController:UIViewController{
             questionView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
             questionView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor)
         ])
+        
+        questionView.widthAnchor.constraint(equalTo: scrollView.widthAnchor).isActive = true
+
     }
 }


### PR DESCRIPTION
답변 창에서 '질문보기' 눌렀을때 보여주는 VC에서 제목이 길면 줄바꿈이 되는 것이 아닌 가로로 스크롤 되던 문제를 수정
- 제목이 길면 화면 내에서 줄바꿈하여 세로로만 스크롤 되도록 수정


\* 제목, 닉네임, 내용, 이미지, 태그, 날짜가 보입니다.